### PR TITLE
feat(nit.ts): add action name in commit data

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,5 @@
+nodeLinker: node-modules
+
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
+    spec: "@yarnpkg/plugin-version"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/command-line-usage": "^5.0.2",
     "@types/crypto-js": "^4.1.1",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.25",
+    "@types/node": "^18.16.1",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "chai": "^4.3.6",
@@ -59,6 +59,6 @@
     "/bin"
   ],
   "volta": {
-    "node": "16.19.0"
+    "node": "18.16.0"
   }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,11 +1,165 @@
-export const Actions = {
-  "action-initial-registration": "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
-  "action-initial-registration-avalanche": "bafkreiavifzn7ntlb6p2lr55k3oezo6pofwvknecukc5auhng4miowcte4",
-  "action-initial-registration-jade": "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
-  "action-commit" :"bafkreiceiqfe4w4g4j46rsi4h4tbqu35ivewfxm4q743tfmegscpg7d63m",
-  "action-mint-erc721-nft-jade": "bafkreiakk6le5wgbl3zz3acybd2wfc2y32mpmxj4kbjjjskom7cy2akwly",
-  "action-mint-erc721-nft-ethereum": "bafkreighzhmelvwlntigjq6ushun4mz36x6cq5nztkvcac47bdxz2ipeca",
-  "action-mint-erc721-nft-avalanche": "bafkreibro4v4vsibvr47uwhkj6gqpc5rfvvq5ykfzzz4jnzvm23zwoh2gq",
-  "action-mint-erc721-nft-polygon": "bafkreigdxfmwhhepusyhaoidyzy6bv7jzpc5liqohyc6numgvvbfwabn6a",
-  "action-mint-erc721-nft-thundercore": "bafkreih7gzxeukcnosbotvpq7hw6htlxoi2dzzm2nnkskloazgw2sbh55i",
+/* Spec of Actions
+ * https://docs.numbersprotocol.io/introduction/numbers-protocol/defining-web3-assets/commit#actions
+ */
+
+export const ActionSet = {
+  // default, the same as action-initial-registration-jade
+  "action-initial-registration": {
+    nid: "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
+    content: {
+      "networkActionName": "initial registration",
+      "blockchain": "jade",
+      "tokenAddress": "",
+      "provider": "bafkreigrt5tepycewppysdwcjccdkdvvc2ztelqv64idgautq52g3vfh4i",
+      "abstract": "Register asset to the Numbers network",
+      "type": "new"
+    }
+  },
+  "action-initial-registration-avalanche": {
+    nid: "bafkreiavifzn7ntlb6p2lr55k3oezo6pofwvknecukc5auhng4miowcte4",
+    content: {
+      "networkActionName": "initial registration",
+      "blockchain": "avalanche",
+      "tokenAddress": "",
+      "provider": "bafkreido4zu743f6isb5wninfkedvbirj2ngb5fkivrpdijh2xtd3s6rnu",
+      "abstract": "Register asset to the Numbers network",
+      "type": "new"
+    }
+  },
+  "action-initial-registration-jade": {
+    nid: "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
+    content: {
+      "networkActionName": "initial registration",
+      "blockchain": "jade",
+      "tokenAddress": "",
+      "provider": "bafkreigrt5tepycewppysdwcjccdkdvvc2ztelqv64idgautq52g3vfh4i",
+      "abstract": "Register asset to the Numbers network",
+      "type": "new"
+    }
+  },
+
+  "action-commit": {
+    nid: "bafkreiceiqfe4w4g4j46rsi4h4tbqu35ivewfxm4q743tfmegscpg7d63m",
+    content: {
+      "networkActionName": "commit",
+      "blockchain": "jade",
+      "tokenAddress": "",
+      "provider": "bafkreigrt5tepycewppysdwcjccdkdvvc2ztelqv64idgautq52g3vfh4i",
+      "abstract": "Commit asset history to Numbers network",
+      "type": "update"
+    }
+  },
+
+  // default, the same as action-mint-erc721-nft-jade
+  "action-mint-erc721-nft": {
+    nid: "bafkreiakk6le5wgbl3zz3acybd2wfc2y32mpmxj4kbjjjskom7cy2akwly",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "jade",
+      "tokenAddress": "",
+      "provider": "bafkreigrt5tepycewppysdwcjccdkdvvc2ztelqv64idgautq52g3vfh4i",
+      "abstract": "Mint ERC-721 NFT on Jade",
+      "type": "update"
+    }
+  },
+  "action-mint-erc721-nft-avalanche": {
+    nid: "bafkreibro4v4vsibvr47uwhkj6gqpc5rfvvq5ykfzzz4jnzvm23zwoh2gq",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "avalanche",
+      "tokenAddress": "",
+      "provider": "bafkreido4zu743f6isb5wninfkedvbirj2ngb5fkivrpdijh2xtd3s6rnu",
+      "abstract": "Mint ERC-721 NFT on Avalanche",
+      "type": "update"
+    }
+  },
+  "action-mint-erc721-nft-ethereum": {
+    nid: "bafkreighzhmelvwlntigjq6ushun4mz36x6cq5nztkvcac47bdxz2ipeca",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "ethereum",
+      "tokenAddress": "",
+      "provider": "bafkreido4zu743f6isb5wninfkedvbirj2ngb5fkivrpdijh2xtd3s6rnu",
+      "abstract": "Mint ERC-721 NFT on Ethereum",
+      "type": "update"
+    }
+  },
+  "action-mint-erc721-nft-jade": {
+    nid: "bafkreiakk6le5wgbl3zz3acybd2wfc2y32mpmxj4kbjjjskom7cy2akwly",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "jade",
+      "tokenAddress": "",
+      "provider": "bafkreigrt5tepycewppysdwcjccdkdvvc2ztelqv64idgautq52g3vfh4i",
+      "abstract": "Mint ERC-721 NFT on Jade",
+      "type": "update"
+    }
+  },
+  "action-mint-erc721-nft-polygon": {
+    nid: "bafkreigdxfmwhhepusyhaoidyzy6bv7jzpc5liqohyc6numgvvbfwabn6a",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "polygon",
+      "tokenAddress": "",
+      "provider": "bafkreido4zu743f6isb5wninfkedvbirj2ngb5fkivrpdijh2xtd3s6rnu",
+      "abstract": "Mint ERC-721 NFT on Polygon",
+      "type": "update"
+    }
+  },
+  "action-mint-erc721-nft-thundercore": {
+    nid: "bafkreih7gzxeukcnosbotvpq7hw6htlxoi2dzzm2nnkskloazgw2sbh55i",
+    content: {
+      "networkActionName": "mint ERC-721 NFT",
+      "blockchain": "thundercore",
+      "tokenAddress": "",
+      "provider": "bafkreido4zu743f6isb5wninfkedvbirj2ngb5fkivrpdijh2xtd3s6rnu",
+      "abstract": "Mint ERC-721 NFT on ThunderCore",
+      "type": "update"
+    }
+  },
 };
+
+/* DESIGN: To keep backward compatibility, we keep Actions.
+ */
+
+function generateNidDictionary(actionSet) {
+  const nidDictionary = {};
+
+  for (const key in actionSet) {
+    if (actionSet.hasOwnProperty(key)) {
+      nidDictionary[key] = actionSet[key].nid;
+    }
+  }
+
+  return nidDictionary;
+}
+
+export const Actions = generateNidDictionary(ActionSet);
+
+/* Return the action key if it's valid, otherwise return "commit". */
+export function getValidActionOrDefault(action: string): string {
+  return Actions.hasOwnProperty(action) ? action : "action-commit";
+}
+
+export function generateNameDictionary(actionSet) {
+  const keyDictionary = {};
+
+  for (const key in actionSet) {
+    if (actionSet.hasOwnProperty(key)) {
+      const nid = actionSet[key].nid;
+      keyDictionary[nid] = key;
+    }
+  }
+
+  return keyDictionary;
+}
+
+export function getNameByNid(actionNid) {
+  const nameDictionary = generateNameDictionary(ActionSet);
+
+  if (nameDictionary.hasOwnProperty(actionNid)) {
+    return nameDictionary[actionNid];
+  } else {
+    return 'action-commit';
+  }
+}

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,6 @@
 export const Actions = {
-  "action-initial-registration": "bafkreiavifzn7ntlb6p2lr55k3oezo6pofwvknecukc5auhng4miowcte4",
+  "action-initial-registration": "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
+  "action-initial-registration-avalanche": "bafkreiavifzn7ntlb6p2lr55k3oezo6pofwvknecukc5auhng4miowcte4",
   "action-initial-registration-jade": "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii",
   "action-commit" :"bafkreiceiqfe4w4g4j46rsi4h4tbqu35ivewfxm4q743tfmegscpg7d63m",
   "action-mint-erc721-nft-jade": "bafkreiakk6le5wgbl3zz3acybd2wfc2y32mpmxj4kbjjjskom7cy2akwly",

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -53,9 +53,30 @@ export async function infuraIpfsCat(cid) {
   return r.rawBody;
 }
 
+export async function w3sIpfsCat(cid) {
+  const url = `https://${cid}.ipfs.w3s.link`;
+  const requestConfig = {
+    timeout: { request: 30000 },
+  }
+  /* FIXME: Axios's response.data.lenght is smaller than content length.
+   * Use Got as a temporary workardound.
+   * https://github.com/axios/axios/issues/3711
+   */
+  const r = await got.get(url, requestConfig);
+  return r.rawBody;
+}
+
+export async function ipfsAddBytes(bytes) {
+  return await infuraIpfsAddBytes(bytes);
+}
+
+export async function ipfsCat(cid) {
+  return await w3sIpfsCat(cid);
+}
+
 export async function cidToJsonString(cid) {
   try {
-    const cidContentBytes = await infuraIpfsCat(cid);
+    const cidContentBytes = await ipfsCat(cid);
     return cidContentBytes.toString();
   } catch(error) {
     console.error(`Failed to download content of CID ${cid}`);

--- a/src/nit.ts
+++ b/src/nit.ts
@@ -186,7 +186,7 @@ function addActionNameInCommit(commitData: string) {
       commitJson["actionName"] = "action-commit";
     }
   }
-  return commitJson;
+  return JSON.stringify(commitJson);
 }
 
 export async function createAssetTreeInitialRegisterRemote(assetBytes,

--- a/src/nit.ts
+++ b/src/nit.ts
@@ -1,8 +1,6 @@
 import { ethers } from "ethers";
 import { BytesLike } from "@ethersproject/bytes"
 
-import got from "got";
-
 import * as action from "./action";
 import * as commitdb from "./commitdb";
 import * as integrityContract from "./contract";

--- a/src/nit.ts
+++ b/src/nit.ts
@@ -127,7 +127,7 @@ const configurableAssetTreeKeys = [
 async function createAssetTreeBaseRemote(assetByes, assetMimetype) {
   let stagingAssetTree: any = {};
   try {
-    stagingAssetTree.assetCid = await ipfs.infuraIpfsAddBytes(assetByes);
+    stagingAssetTree.assetCid = await ipfs.ipfsAddBytes(assetByes);
     // remove leading 0x to as the same as most sha256 tools
     stagingAssetTree.assetSha256 = (await ethers.utils.sha256(assetByes)).substring(2);
     stagingAssetTree.encodingFormat = assetMimetype;
@@ -155,7 +155,7 @@ async function createCommitBase(signer, assetTree, authorAddress, providerCid) {
   let stagingCommit: any = {};
 
   const assetTreeBytes = Buffer.from(JSON.stringify(assetTree, null, 2));
-  stagingCommit.assetTreeCid = await ipfs.infuraIpfsAddBytes(assetTreeBytes);
+  stagingCommit.assetTreeCid = await ipfs.ipfsAddBytes(assetTreeBytes);
   stagingCommit.assetTreeSha256 = (await ethers.utils.sha256(Buffer.from(JSON.stringify(assetTree, null, 2)))).substring(2);
   // remove leading 0x to as the same as most sha256 tools
   stagingCommit.assetTreeSignature = await signIntegrityHash(stagingCommit.assetTreeSha256, signer);
@@ -380,8 +380,8 @@ export async function difference(assetCid: string, blockchainInfo, fromIndex: nu
   const commits = await getCommits(commitEvents);
   const fromCommit = commits[0];
   const toCommit = commits[commits.length - 1];
-  const fromAssetTree = JSON.parse((await ipfs.infuraIpfsCat(fromCommit.commit.assetTreeCid)).toString());
-  const toAssetTree = JSON.parse((await ipfs.infuraIpfsCat(toCommit.commit.assetTreeCid)).toString());
+  const fromAssetTree = JSON.parse((await ipfs.ipfsCat(fromCommit.commit.assetTreeCid)).toString());
+  const toAssetTree = JSON.parse((await ipfs.ipfsCat(toCommit.commit.assetTreeCid)).toString());
   const commitDiff = {
     "fromIndex": fromIndex,
     "fromBlockNumber": fromCommit.blockNumber,
@@ -404,7 +404,7 @@ export async function getLatestCommitSummary(assetCid, blockchainInfo) {
 }
 
 export async function getAssetTree(assetTreeCid) {
-  const assetTreeBytes = await ipfs.infuraIpfsCat(assetTreeCid);
+  const assetTreeBytes = await ipfs.ipfsCat(assetTreeCid);
   const assetTree = JSON.parse(assetTreeBytes.toString());
   return assetTree;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -410,7 +410,7 @@ async function assetSourceToBytes(source) {
   let assetBytes;
   if (source.substring(0, 4) === "bafy") {
     console.log("source cid");
-    assetBytes = await ipfs.infuraIpfsCat(source);
+    assetBytes = await ipfs.ipfsCat(source);
   } else if (source.substring(0, 4) === "http") {
     console.log("source http");
     assetBytes = (await got.get(source, { timeout: { request: 30000 } })).rawBody;
@@ -457,7 +457,7 @@ async function main() {
 
   if (args.command === "ipfsadd") {
     const contentBytes = fs.readFileSync(args.params.fileapth);
-    const assetCid = await ipfs.infuraIpfsAddBytes(contentBytes);
+    const assetCid = await ipfs.ipfsAddBytes(contentBytes);
     console.log(`Command ipfsadd result (Asset CID): ${assetCid}`);
   } else if (args.command === "addv1") {
     const assetTreeFileContent = fs.readFileSync(args.params.filepath, "utf-8");
@@ -476,7 +476,7 @@ async function main() {
 
     // Get assetTreeCid and encodingFormat
     const contentBytes = fs.readFileSync(`${commitDir}/assetTree.json`);
-    const assetCid= await ipfs.infuraIpfsAddBytes(contentBytes);
+    const assetCid= await ipfs.ipfsAddBytes(contentBytes);
 
     // Get assetTreeSha256
     const assetTreeSha256 = sha256(assetTreeFileContent);
@@ -506,7 +506,7 @@ async function main() {
 
     let assetCid;
     if ("mockup" in args.params === false) {
-      assetCid = await ipfs.infuraIpfsAddBytes(assetBytes);
+      assetCid = await ipfs.ipfsAddBytes(assetBytes);
     } else {
       assetCid = "a".repeat(nit.cidv1Length);
     }

--- a/tests/testAction.ts
+++ b/tests/testAction.ts
@@ -1,0 +1,34 @@
+/* manual test: ./node_modules/mocha/bin/mocha -r ts-node/register --timeout 10000 tests/testAction.ts
+ */
+
+import { expect } from "chai";
+import * as action from "../src/action";
+
+describe("Action Tests", function() {
+  it("Check action by providing a valid action", async function () {
+    const validAction = "action-initial-registration";
+    expect(action.getValidActionOrDefault(validAction)).to.be.equal(validAction);
+  });
+
+  it("Check action by providing an invalid action", async function () {
+    const validAction = "action-invalid";
+    expect(action.getValidActionOrDefault(validAction)).to.be.equal("action-commit");
+  });
+
+  it("Check action by providing a valid Action Nid", async function () {
+    const validActionNid = "bafkreicptxn6f752c4pvb6gqwro7s7wb336idkzr6wmolkifj3aafhvwii";
+    const expectedActionName = "action-initial-registration-jade";
+    expect(action.getNameByNid(validActionNid)).to.be.equal(expectedActionName);
+  });
+
+  it("Check action by providing an invalid action", async function () {
+    const invalidActionNid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const expectedActionName = "action-commit";
+    expect(action.getNameByNid(invalidActionNid)).to.be.equal(expectedActionName);
+  });
+
+  it("Debugging messages", async function () {
+    console.log(`action: ${JSON.stringify(action.Actions, null, 2)}`);
+    console.log(`action names: ${JSON.stringify(action.generateNameDictionary(action.ActionSet), null, 2)}`);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,10 +730,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
   integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
 
-"@types/node@^17.0.25":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
-  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+"@types/node@^18.16.1":
+  version "18.16.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.1.tgz#5db121e9c5352925bb1f1b892c4ae620e3526799"
+  integrity sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
- Add actionName in commit data. [#21](https://github.com/numbersprotocol/nit/pull/21)
  - Check if `actionName` is sent
     - If yes, use the `actionName` defined by the App
     - If no, the default` acitonName` will be $networkActionName found in the IPFS file of action
        (for non-jade blockchain, will be $networkActionName + '-' + $blockchain)
  - If there is no action specified or the action is not yet defined in `action.ts`, will use `commit` as the default action.
- Change action definition. [#21](https://github.com/numbersprotocol/nit/pull/21)
  - `action-initial-registration` becomes `action-initial-registration-jade`
  - Add `action-initial-registration-avalanche` which is the original `action-initial-registration`