### PR TITLE
feat(src): Remove default license from asset tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "dev-global-uninstall": "yarn global remove @numbersprotocol/nit",
     "dev-install": "yarn run build && yarn add file:$PWD",
     "dev-uninstall": "yarn remove @numbersprotocol/nit && yarn run clean",
-    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts'",
-    "test-single": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register"
+    "test": "mocha -r ts-node/register 'tests/**/*.ts'",
+    "test-single": "mocha -r ts-node/register"
   },
   "bin": "bin/nit.js",
   "devDependencies": {

--- a/src/license.ts
+++ b/src/license.ts
@@ -1,36 +1,37 @@
 /* Reference: https://pypi.org/classifiers/
+              https://spdx.org/licenses/
  */
 export const Licenses = {
   "cc-by": {
-    "name": "Creative Commons Attribution 4.0 International",
-    "document": "https://creativecommons.org/licenses/by/4.0/"
+    "name": "CC-BY-4.0",
+    "document": "https://creativecommons.org/licenses/by/4.0/legalcode"
   },
   "cc-by-sa": {
-    "name": "Creative Commons Attribution-ShareAlike 4.0 International",
-    "document": "https://creativecommons.org/licenses/by-sa/4.0/"
+    "name": "CC-BY-SA-4.0",
+    "document": "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
   },
   "cc-by-nd": {
-    "name": "Creative Commons Attribution-NoDerivatives 4.0 International",
-    "document": "https://creativecommons.org/licenses/by-nd/4.0/"
+    "name": "CC-BY-ND-4.0",
+    "document": "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
   },
   "cc-by-nc": {
-    "name": "Creative Commons Attribution-NonCommercial 4.0 International",
-    "document": "https://creativecommons.org/licenses/by-nc/4.0/"
+    "name": "CC-BY-NC-4.0",
+    "document": "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
   },
   "cc-by-nc-sa": {
-    "name": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International",
-    "document": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+    "name": "CC-BY-NC-SA-4.0",
+    "document": "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
   },
   "cc-by-nc-nd": {
-    "name": "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International",
-    "document": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+    "name": "CC-BY-NC-ND-4.0",
+    "document": "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
   },
   "mit": {
-    "name": "mit",
+    "name": "MIT",
     "document": "https://opensource.org/licenses/MIT"
   },
   "public": {
-    "name": "public-domain",
+    "name": "MIT",
     "document": "https://opensource.org/licenses/MIT"
   },
 };

--- a/src/license.ts
+++ b/src/license.ts
@@ -1,28 +1,30 @@
-/* Reference: https://pypi.org/classifiers/
-              https://spdx.org/licenses/
+/* References:
+ *   https://spdx.org/licenses/
+ *   https://pypi.org/classifiers/
  */
+
 export const Licenses = {
-  "cc-by": {
+  "cc-by-4.0": {
     "name": "CC-BY-4.0",
     "document": "https://creativecommons.org/licenses/by/4.0/legalcode"
   },
-  "cc-by-sa": {
+  "cc-by-sa-4.0": {
     "name": "CC-BY-SA-4.0",
     "document": "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
   },
-  "cc-by-nd": {
+  "cc-by-nd-4.0": {
     "name": "CC-BY-ND-4.0",
     "document": "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
   },
-  "cc-by-nc": {
+  "cc-by-nc-4.0": {
     "name": "CC-BY-NC-4.0",
     "document": "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
   },
-  "cc-by-nc-sa": {
+  "cc-by-nc-sa-4.0": {
     "name": "CC-BY-NC-SA-4.0",
     "document": "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
   },
-  "cc-by-nc-nd": {
+  "cc-by-nc-nd-4.0": {
     "name": "CC-BY-NC-ND-4.0",
     "document": "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
   },
@@ -36,7 +38,7 @@ export const Licenses = {
   },
 };
 
-export const DefaultLicense: string = "cc-by-nc";
+export const DefaultLicense: string = "cc-by-nc-4.0";
 
 export function isSupportedLicense(licenseName: string) {
   if (Object.keys(Licenses).indexOf(licenseName) > -1) {

--- a/src/nit.ts
+++ b/src/nit.ts
@@ -189,17 +189,27 @@ function addActionNameInCommit(commitData: string) {
   return JSON.stringify(commitJson);
 }
 
+function addLicenseInAssetTree(assetTree: {[key: string]: any}, assetLicense?: string | undefined) {
+  if (assetLicense) {
+    if (license.isSupportedLicense(assetLicense)) {
+      assetTree.license = license.Licenses[assetLicense];
+    } else {
+      console.error(`Get unsupported license: ${assetLicense}\n`);
+    }
+  }
+}
+
 export async function createAssetTreeInitialRegisterRemote(assetBytes,
                                                            assetMimetype,
                                                            assetTimestampCreated,
                                                            assetCreator,
-                                                           assetLicense="cc-by-nc",
+                                                           assetLicense: string | undefined = undefined,
                                                            assetAbstract="") {
   let stagingAssetTree = await createAssetTreeBaseRemote(assetBytes, assetMimetype);
   stagingAssetTree.assetTimestampCreated= assetTimestampCreated;
   stagingAssetTree.assetCreator = assetCreator;
-  stagingAssetTree.license = license.Licenses[assetLicense];
   stagingAssetTree.abstract = assetAbstract;
+  addLicenseInAssetTree(stagingAssetTree, assetLicense);
   return stagingAssetTree;
 }
 
@@ -208,13 +218,13 @@ export async function createAssetTreeInitialRegister(assetCid,
                                                      assetMimetype,
                                                      assetTimestampCreated,
                                                      assetCreator,
-                                                     assetLicense="cc-by-nc",
+                                                     assetLicense: string | undefined = undefined,
                                                      assetAbstract="") {
   let stagingAssetTree = await createAssetTreeBase(assetCid, assetSha256, assetMimetype);
   stagingAssetTree.assetTimestampCreated= assetTimestampCreated;
   stagingAssetTree.assetCreator = assetCreator;
-  stagingAssetTree.license = license.Licenses[assetLicense];
   stagingAssetTree.abstract = assetAbstract;
+  addLicenseInAssetTree(stagingAssetTree, assetLicense);
   return stagingAssetTree;
 }
 

--- a/tests/testNit.ts
+++ b/tests/testNit.ts
@@ -1,0 +1,71 @@
+/* manual test: yarn run mocha -r ts-node/register tests/testNit.ts
+ */
+
+import fs = require("fs");
+import os = require("os");
+
+import { expect } from "chai";
+import * as nit from "../src/nit";
+
+describe("Nit", function() {
+  const configFilepath = `${os.homedir()}/.nitconfig.json`;
+  let config;
+  let imageUrl;
+  let imageCid;
+
+  /* Asset Tree of the generative AI example #1
+   * https://nftsearch.site/asset-profile?nid=bafkreid4ug5djtm6iq6hptfs337n3k3driqncivegexzpffzlapiaple44
+   */
+  const gaiAssetTree = {
+    "assetCid": "bafkreid4ug5djtm6iq6hptfs337n3k3driqncivegexzpffzlapiaple44",
+    "assetSha256": "7ca1ba34cd9e443c77ccb2defeddab638a20d122a4312f9794b9581e803d64e7",
+    "encodingFormat": "image/jpeg",
+    "assetTimestampCreated": 1683287179,
+    "assetCreator": "",
+    "license": {
+      "name": null,
+      "document": null
+    },
+    "abstract": "",
+    "assetSourceType": "captureUpload",
+    "creatorWallet": "0x6059DFC1daFb109474aB6fAD87E93A11Bfa5e1D2"
+  };
+
+  beforeEach(async function () {
+    config = JSON.parse(fs.readFileSync(`${configFilepath}`, "utf-8"));
+    imageUrl = "https://assets.website-files.com/6148548ab244696560ef92dd/614ba33bb06974479683baa0_Numbers.svg";
+    imageCid = "bafkreica6gtp7mgqtxcmcj2mwa2fzdd6tq3xuzmsoozrijksagqii7elly";
+  });
+
+  it(".. should add a valid license successfully", async function () {
+    const stagingAssetTree = await nit.createAssetTreeInitialRegister(
+      gaiAssetTree.assetCid,
+      gaiAssetTree.assetSha256,
+      gaiAssetTree.encodingFormat,
+      gaiAssetTree.assetTimestampCreated,
+      gaiAssetTree.assetCreator,
+      "cc-by-nc-nd-4.0",
+      gaiAssetTree.abstract
+    );
+
+    await expect(stagingAssetTree.license.name).to.be.equal("CC-BY-NC-ND-4.0");
+    await expect(stagingAssetTree.license.document).to.be.equal("https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode");
+  });
+
+  /* TODO: For the key with null or undefined, should we keep the key or remove it?
+   * We remove the key for now.
+   */
+  it(".. should add an invalid license without breaking program", async function () {
+    const stagingAssetTree = await nit.createAssetTreeInitialRegister(
+      gaiAssetTree.assetCid,
+      gaiAssetTree.assetSha256,
+      gaiAssetTree.encodingFormat,
+      gaiAssetTree.assetTimestampCreated,
+      gaiAssetTree.assetCreator,
+      "cc-by-nc-nd-invalid",
+      gaiAssetTree.abstract
+    );
+
+    await expect(stagingAssetTree.license).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Changed
- Remove the assignment of a default license to the asset tree. [#26](https://github.com/numbersprotocol/nit/pull/26)
- Improving the license identification and document URLs. [#26](https://github.com/numbersprotocol/nit/pull/26)
  - Enhance the usage of SPDX license identifiers for improved license identification.
  - Update the license document URLs to point to the legal code of each license.

By removing the default license and improving the license identification and document URLs, we ensure that the asset tree accurately reflects the license information without any assumptions.