### PR TITLE
fix(src/nit.ts): empty abstract without input

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,8 @@
     "dev-global-uninstall": "yarn global remove @numbersprotocol/nit",
     "dev-install": "yarn run build && yarn add file:$PWD",
     "dev-uninstall": "yarn remove @numbersprotocol/nit && yarn run clean",
-<<<<<<< Updated upstream
-    "test": "mocha -r ts-node/register 'tests/**/*.ts'",
+    "test": "mocha -r ts-node/register tests/**/*.ts",
     "test-single": "mocha -r ts-node/register"
-=======
-    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts'",
-    "test-single": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register",
-    "lint": "eslint --ext .ts ."
->>>>>>> Stashed changes
   },
   "bin": "bin/nit.js",
   "devDependencies": {

--- a/src/license.ts
+++ b/src/license.ts
@@ -38,11 +38,7 @@ export const Licenses = {
   },
 };
 
-<<<<<<< Updated upstream
 export const DefaultLicense: string = "cc-by-nc-4.0";
-=======
-export const DefaultLicense = "cc-by-nc";
->>>>>>> Stashed changes
 
 export function isSupportedLicense(licenseName: string) {
   if (Object.keys(Licenses).indexOf(licenseName) > -1) {

--- a/src/nit.ts
+++ b/src/nit.ts
@@ -199,17 +199,23 @@ function addLicenseInAssetTree(assetTree: {[key: string]: any}, assetLicense?: s
   }
 }
 
+function addAbstractInAssetTree(assetTree: {[key: string]: any}, assetAbstract?: string | undefined) {
+  if (assetAbstract !== undefined) {
+    assetTree.abstract = assetAbstract;
+  }
+}
+
 export async function createAssetTreeInitialRegisterRemote(assetBytes,
                                                            assetMimetype,
                                                            assetTimestampCreated,
                                                            assetCreator,
                                                            assetLicense: string | undefined = undefined,
-                                                           assetAbstract="") {
+                                                           assetAbstract: string | undefined = undefined) {
   let stagingAssetTree = await createAssetTreeBaseRemote(assetBytes, assetMimetype);
   stagingAssetTree.assetTimestampCreated= assetTimestampCreated;
   stagingAssetTree.assetCreator = assetCreator;
-  stagingAssetTree.abstract = assetAbstract;
   addLicenseInAssetTree(stagingAssetTree, assetLicense);
+  addAbstractInAssetTree(stagingAssetTree, assetAbstract);
   return stagingAssetTree;
 }
 
@@ -219,12 +225,12 @@ export async function createAssetTreeInitialRegister(assetCid,
                                                      assetTimestampCreated,
                                                      assetCreator,
                                                      assetLicense: string | undefined = undefined,
-                                                     assetAbstract="") {
+                                                     assetAbstract: string | undefined = undefined) {
   let stagingAssetTree = await createAssetTreeBase(assetCid, assetSha256, assetMimetype);
   stagingAssetTree.assetTimestampCreated= assetTimestampCreated;
   stagingAssetTree.assetCreator = assetCreator;
-  stagingAssetTree.abstract = assetAbstract;
   addLicenseInAssetTree(stagingAssetTree, assetLicense);
+  addAbstractInAssetTree(stagingAssetTree, assetAbstract);
   return stagingAssetTree;
 }
 

--- a/tests/testNit.ts
+++ b/tests/testNit.ts
@@ -68,4 +68,37 @@ describe("Nit", function() {
 
     await expect(stagingAssetTree.license).to.be.undefined;
   });
+
+  it(".. should add an abstract successfully", async function () {
+    gaiAssetTree.abstract = "";
+
+    const stagingAssetTree = await nit.createAssetTreeInitialRegister(
+      gaiAssetTree.assetCid,
+      gaiAssetTree.assetSha256,
+      gaiAssetTree.encodingFormat,
+      gaiAssetTree.assetTimestampCreated,
+      gaiAssetTree.assetCreator,
+      "cc-by-nc-nd-4.0",
+      gaiAssetTree.abstract
+    );
+
+    await expect(stagingAssetTree.abstract).to.be.equal("");
+  });
+
+  /* TODO: For the key with null or undefined, should we keep the key or remove it?
+   * We remove the key for now.
+   */
+  it(".. should add an invalid abstract without breaking program", async function () {
+    const stagingAssetTree = await nit.createAssetTreeInitialRegister(
+      gaiAssetTree.assetCid,
+      gaiAssetTree.assetSha256,
+      gaiAssetTree.encodingFormat,
+      gaiAssetTree.assetTimestampCreated,
+      gaiAssetTree.assetCreator,
+      "cc-by-nc-nd-4.0",
+      undefined
+    );
+
+    await expect(stagingAssetTree.abstract).to.be.undefined;
+  });
 });


### PR DESCRIPTION
## Changed
- Remove the assignment of a default empty abstract to the asset tree. [#27](https://github.com/numbersprotocol/nit/pull/27)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1203248692432100/1204803772325985) by [Unito](https://www.unito.io)
