### PR TITLE
fix(run.ts): commit transaction not included

### DIFF
--- a/src/nit.ts
+++ b/src/nit.ts
@@ -315,7 +315,7 @@ export async function pull(assetCid: string, blockchainInfo) {
 //  }
 //}
 
-export async function commit(assetCid: string, commitData: string, blockchainInfo) {
+export async function commit(assetCid: string, commitData: string, blockchainInfo, confirms: number = 1) {
   const commitString = addActionNameInCommit(commitData);
   let r;
   if (blockchainInfo.gasPrice != null) {
@@ -324,7 +324,9 @@ export async function commit(assetCid: string, commitData: string, blockchainInf
   } else {
     r = await blockchainInfo.contract.commit(assetCid, commitString, { gasLimit: blockchainInfo.gasLimit });
   }
-  return r;
+
+  // Wait for the transaction to be mined
+  return await r.wait(confirms);
 }
 
 export async function log(assetCid: string, blockchainInfo, fromIndex: number, toIndex: number = null) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -609,15 +609,11 @@ async function main() {
       } else {
         commitEventIndexCid = nit.assetCidMock;
       }
-      const commitResult = await nit.commit(commitEventIndexCid, JSON.stringify(commitData), blockchain);
-
-      console.log(`Commit Tx: ${commitResult.hash}`);
-      console.log(`Commit Explorer: ${blockchain.explorerBaseUrl}/${commitResult.hash}`);
 
       try {
-        // Wait for the transaction to be mined
-        const transactionReceipt = await commitResult.wait();
-        console.log(`Block Number: ${transactionReceipt.blockNumber}`);
+        const transactionReceipt = await nit.commit(commitEventIndexCid, JSON.stringify(commitData), blockchain);
+        console.log(`Commit Tx: ${transactionReceipt.transactionHash}`);
+        console.log(`Commit Explorer: ${blockchain.explorerBaseUrl}/${transactionReceipt.transactionHash}`);
       } catch (error) {
         console.error(`Transaction error: ${error}`);
       }

--- a/src/run.ts
+++ b/src/run.ts
@@ -614,6 +614,14 @@ async function main() {
       console.log(`Commit Tx: ${commitResult.hash}`);
       console.log(`Commit Explorer: ${blockchain.explorerBaseUrl}/${commitResult.hash}`);
 
+      try {
+        // Wait for the transaction to be mined
+        const transactionReceipt = await commitResult.wait();
+        console.log(`Block Number: ${transactionReceipt.blockNumber}`);
+      } catch (error) {
+        console.error(`Transaction error: ${error}`);
+      }
+
       // Reset stage
       await setWorkingAssetCid("");
 


### PR DESCRIPTION
## Fixed
- Fix the issue where the transaction was successfully committed and a transaction hash was obtained, but the transaction was never included in a block. [#29](https://github.com/numbersprotocol/nit/pull/29)

Add a wait mechanism to ensure the transaction is mined or log the error reason if it fails.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1203248692432100/1204823233860165) by [Unito](https://www.unito.io)
